### PR TITLE
Add API key authentication to server and notebook client

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This project aims to create a simple MCP (Multi-Component Platform) server with 
 
 ## Project Plan
 
-1. **MCP Server**  
+1. **MCP Server**
    - Build a minimal MCP server exposing a public API.
    - Focus on clarity and ease of understanding for each component.
 
-2. **Jupyter Notebook Client**  
+2. **Jupyter Notebook Client**
    - Create a Jupyter notebook that connects to the MCP server.
    - Use the MCP server as part of a request to the OpenAI API.
    - Enable interactive chat with the content managed by the MCP server.
@@ -22,10 +22,15 @@ This project aims to create a simple MCP (Multi-Component Platform) server with 
 ## Getting Started
 
 1. **Run the MCP Server**
-    - Instructions for running the server will be provided in future commits.
+    - Set an API key in the environment:
+      ```bash
+      export MCP_API_KEY="secret-key"
+      python server.py
+      ```
+    - The server requires the key to be sent in the `X-API-Key` header.
 
 2. **Use the Jupyter Notebook**
-    - The notebook will show how to connect to the MCP server and interact with the OpenAI API.
+    - The notebook reads `MCP_API_KEY` from the environment and uses it when calling the server.
 
 ## License
 

--- a/client.ipynb
+++ b/client.ipynb
@@ -1,0 +1,31 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import requests\n",
+    "\n",
+    "API_KEY = os.environ.get('MCP_API_KEY', 'secret-key')\n",
+    "response = requests.get('http://localhost:8000/ping', headers={'X-API-Key': API_KEY})\n",
+    "response.json()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+requests

--- a/server.py
+++ b/server.py
@@ -1,0 +1,15 @@
+import os
+from flask import Flask, request, jsonify, abort
+
+app = Flask(__name__)
+API_KEY = os.environ.get("MCP_API_KEY", "secret-key")
+
+@app.route("/ping")
+def ping():
+    key = request.headers.get("X-API-Key")
+    if key != API_KEY:
+        abort(401)
+    return jsonify({"message": "pong"})
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)

--- a/test_server.py
+++ b/test_server.py
@@ -1,0 +1,21 @@
+import os
+import importlib
+
+# Ensure environment variable is set before importing server
+os.environ["MCP_API_KEY"] = "test-key"
+
+import server
+importlib.reload(server)
+
+
+def test_ping_with_api_key():
+    app = server.app.test_client()
+    res = app.get("/ping", headers={"X-API-Key": "test-key"})
+    assert res.status_code == 200
+    assert res.get_json() == {"message": "pong"}
+
+
+def test_ping_without_api_key():
+    app = server.app.test_client()
+    res = app.get("/ping")
+    assert res.status_code == 401


### PR DESCRIPTION
## Summary
- Require `X-API-Key` header for the `/ping` endpoint in the Flask server
- Document API key usage and provide notebook that sends the key when calling the server
- Add tests verifying authorized and unauthorized requests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0d49f0a50832c95bcdec0514bda0e