### PR TITLE
Switch to fastmcp server with GitHub Zen tool

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-flask
-requests
+fastmcp>=2.0,<3.0

--- a/server.py
+++ b/server.py
@@ -1,15 +1,24 @@
-import os
-from flask import Flask, request, jsonify, abort
+from __future__ import annotations
 
-app = Flask(__name__)
-API_KEY = os.environ.get("MCP_API_KEY", "secret-key")
+import httpx
+from fastmcp import FastMCP
 
-@app.route("/ping")
-def ping():
-    key = request.headers.get("X-API-Key")
-    if key != API_KEY:
-        abort(401)
-    return jsonify({"message": "pong"})
+server = FastMCP()
+
+
+@server.tool()
+def ping() -> str:
+    """Return a simple pong response."""
+    return "pong"
+
+
+@server.tool()
+def github_zen() -> str:
+    """Fetch a random message from the GitHub Zen API."""
+    response = httpx.get("https://api.github.com/zen", timeout=10)
+    response.raise_for_status()
+    return response.text.strip()
+
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=8000)
+    server.run()

--- a/test_server.py
+++ b/test_server.py
@@ -1,21 +1,12 @@
-import os
-import importlib
-
-# Ensure environment variable is set before importing server
-os.environ["MCP_API_KEY"] = "test-key"
-
+import asyncio
 import server
-importlib.reload(server)
 
+def test_ping_tool():
+    res = asyncio.run(server.ping.run({}))
+    assert res.content[0].text == "pong"
 
-def test_ping_with_api_key():
-    app = server.app.test_client()
-    res = app.get("/ping", headers={"X-API-Key": "test-key"})
-    assert res.status_code == 200
-    assert res.get_json() == {"message": "pong"}
+def test_github_zen_tool():
+    res = asyncio.run(server.github_zen.run({}))
+    assert isinstance(res.content[0].text, str)
+    assert res.content[0].text
 
-
-def test_ping_without_api_key():
-    app = server.app.test_client()
-    res = app.get("/ping")
-    assert res.status_code == 401


### PR DESCRIPTION
## Summary
- replace Flask app with FastMCP server
- add example `github_zen` tool using GitHub Zen public API
- update tests and requirements for FastMCP 2.0

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c22fa43780832cb226be9c48805f50