### PR TITLE
Allow processing of user-provided GICS files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This project aims to create a simple MCP (Multi-Component Platform) server with 
 1. **MCP Server**
    - Build a minimal MCP server exposing a public API.
    - Focus on clarity and ease of understanding for each component.
+   - Allow users to submit a URL to a GICS CSV file and process its contents.
 
 2. **Jupyter Notebook Client**
    - Create a Jupyter notebook that connects to the MCP server.

--- a/server.py
+++ b/server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import csv
 import httpx
 from fastmcp import FastMCP
 
@@ -18,6 +19,19 @@ def github_zen() -> str:
     response = httpx.get("https://api.github.com/zen", timeout=10)
     response.raise_for_status()
     return response.text.strip()
+
+
+@server.tool()
+def process_gics(url: str) -> str:
+    """Fetch a GICS CSV file from the provided URL and report the number of records."""
+    response = httpx.get(url, timeout=10)
+    response.raise_for_status()
+
+    reader = csv.reader(response.text.splitlines())
+    rows = list(reader)
+    num_records = len(rows) - 1 if rows else 0
+
+    return f"Processed {num_records} GICS records"
 
 
 if __name__ == "__main__":

--- a/test_server.py
+++ b/test_server.py
@@ -1,4 +1,5 @@
 import asyncio
+import httpx
 import server
 
 def test_ping_tool():
@@ -9,4 +10,17 @@ def test_github_zen_tool():
     res = asyncio.run(server.github_zen.run({}))
     assert isinstance(res.content[0].text, str)
     assert res.content[0].text
+
+
+def test_process_gics_tool(monkeypatch):
+    sample_csv = "code,sector\n10,Energy\n15,Materials\n"
+
+    def mock_get(url, timeout):
+        request = httpx.Request("GET", url)
+        return httpx.Response(200, text=sample_csv, request=request)
+
+    monkeypatch.setattr(server.httpx, "get", mock_get)
+
+    res = asyncio.run(server.process_gics.run({"url": "http://example.com/gics.csv"}))
+    assert res.content[0].text == "Processed 2 GICS records"
 


### PR DESCRIPTION
## Summary
- enable processing of GICS CSV files from user-supplied URLs
- document new GICS processing capability
- test GICS processing workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c749ea720c832c8ea57fdbcd328738